### PR TITLE
tasksテーブルのnameカラムにNOT NULL制約を追加

### DIFF
--- a/db/migrate/20200913045154_change_tasks_name_not_null.rb
+++ b/db/migrate/20200913045154_change_tasks_name_not_null.rb
@@ -1,0 +1,5 @@
+class ChangeTasksNameNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :tasks, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_07_014154) do
+ActiveRecord::Schema.define(version: 2020_09_13_045154) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
1. 新しくマイグレーションファイルを作成
2. change_column_null, false を使用してNOT NULL制約を追加